### PR TITLE
Add GitClear PR tool to list of code review tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Feel free to contribute your suggestions.
 
 | Tool | Description |
 | ---- | ----------- |
-| [Gitpod](https://gitpod.io/) | Always ready to code - spin up fresh, automated dev environments for each task, in the cloud, in seconds.
-Gitpod is an open-source developer platform automating the provisioning of ready-to-code developer environments. |
+| [Gitpod](https://gitpod.io/) | Always ready to code - spin up fresh, automated dev environments for each task, in the cloud, in seconds. Gitpod is an open-source developer platform automating the provisioning of ready-to-code developer environments. |
+| [GitClear Pull Request Review](https://www.gitclear.com/best_github_alternative_pull_request_review_tool) | A pull request tool inspired by Github's review tool that recognizes several types of code operations ("moved," "find/replace," "copy/paste") that reduce "lines to review" by 20-30% [in published research](https://www.gitclear.com/research_studies/pull_request_diff_methods_comparison_faster_review). The tool also identifies AI-generated code and offers an explanation for each changed line by hoving on the line, plus Slack notifications for "stuck" PRs. |
 | [Pull Reminders](https://pullreminders.com/) (from Pull Panda) | Review and merge pull requests faster with Slack reminders and notifications. |
 | [Pull Assigner](https://pullpanda.com/assigner) (from Pull Panda) | Pull Assigner assigns code reviews to make your process more balanced and efficient: 1) Organize reviewers into groups using GitHub Teams 2) Assign pull requests to teams or automate it with CODEOWNERS 3) Pull Assigner auto-assigns one or more members of the team as reviewers. |
 | [Gitify](https://www.gitify.io/) | Gitify is all about making your life easier. Sitting on your menu bar, it informs you of any GitHub notifications without being annoying and of course without adverts. It just gets the job done. Works with GitHub and GitHub Enterprise. You can even connect multiple accounts. |


### PR DESCRIPTION
Add GitClear's PR tool (launched in 2024) to the list of available code review tools.